### PR TITLE
Update the part that might violate the clean archititure and the SOLD

### DIFF
--- a/src/main/java/interface_adapter/ViewNames.java
+++ b/src/main/java/interface_adapter/ViewNames.java
@@ -1,0 +1,23 @@
+package interface_adapter;
+
+/**
+ * Constants for view names to avoid hardcoded strings.
+ * Follows Single Responsibility Principle - centralized view name management.
+ * Prevents violations of Clean Architecture by decoupling layers from specific view names.
+ */
+public class ViewNames {
+    private ViewNames() {
+        throw new AssertionError("Cannot instantiate ViewNames class");
+    }
+
+    public static final String SIGNUP = "sign up";
+    public static final String LOGIN = "log in";
+    public static final String LOGGED_IN = "logged in";
+    public static final String DISPLAY_LOCAL_EVENTS = "display local events";
+    public static final String CALENDAR = "calendar view";
+    public static final String EVENT_LIST_BY_DATE = "event list by date";
+    public static final String EVENT_DESCRIPTION = "event description";
+    public static final String EVENT_SEARCH = "event search";
+    public static final String SAVE_EVENTS = "save events";
+
+}

--- a/src/main/java/interface_adapter/calendarFlow/CalendarFlowPresenter.java
+++ b/src/main/java/interface_adapter/calendarFlow/CalendarFlowPresenter.java
@@ -3,6 +3,7 @@ package interface_adapter.calendarFlow;
 import java.util.ArrayList;
 
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewNames;
 import use_case.calendarFlow.CalendarFlowOutputBoundary;
 import use_case.calendarFlow.CalendarFlowOutputData;
 
@@ -41,7 +42,7 @@ public class CalendarFlowPresenter implements CalendarFlowOutputBoundary {
 
     @Override
     public void switchToDashboardView() {
-        viewManagerModel.setState("display local events");
+        viewManagerModel.setState(ViewNames.DISPLAY_LOCAL_EVENTS);
         viewManagerModel.firePropertyChange();
     }
 }

--- a/src/main/java/interface_adapter/login/LoginPresenter.java
+++ b/src/main/java/interface_adapter/login/LoginPresenter.java
@@ -1,6 +1,7 @@
 package interface_adapter.login;
 
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewNames;
 import interface_adapter.logged_in.LoggedInState;
 import interface_adapter.logged_in.LoggedInViewModel;
 import interface_adapter.signup.SignupViewModel;
@@ -27,22 +28,6 @@ public class LoginPresenter implements LoginOutputBoundary {
         this.signUpViewModel = signupViewModel;
     }
 
-    // OLD CODE
-//    @Override
-//    public void prepareSuccessView(LoginOutputData response) {
-//        // On success, update the loggedInViewModel's state
-//        final LoggedInState loggedInState = loggedInViewModel.getState();
-//        loggedInState.setUsername(response.getUsername());
-//        this.loggedInViewModel.firePropertyChange();
-//
-//        // and clear everything from the LoginViewModel's state
-//        loginViewModel.setState(new LoginState());
-//
-//        // switch to the logged in view
-//        viewManagerModel.setState("display local events");
-//        viewManagerModel.firePropertyChange();
-//    }
-
     @Override
     public void prepareSuccessView(LoginOutputData response) {
         final LoggedInState loggedInState = loggedInViewModel.getState();
@@ -52,10 +37,9 @@ public class LoginPresenter implements LoginOutputBoundary {
         loginViewModel.setState(new LoginState());
 
         // The view will load the user's location when it becomes visible
-        viewManagerModel.setState("display local events");
+        viewManagerModel.setState(ViewNames.DISPLAY_LOCAL_EVENTS);
         viewManagerModel.firePropertyChange();
     }
-
 
     @Override
     public void prepareFailView(String error) {

--- a/src/main/java/interface_adapter/save_event/SaveEventPresenter.java
+++ b/src/main/java/interface_adapter/save_event/SaveEventPresenter.java
@@ -1,6 +1,7 @@
 package interface_adapter.save_event;
 
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewNames;
 import use_case.save_event.SaveEventOutputBoundary;
 import use_case.save_event.SaveEventOutputData;
 
@@ -32,9 +33,8 @@ public class SaveEventPresenter implements SaveEventOutputBoundary {
 
     @Override
     public void switchToDashboardView() {
-        viewManagerModel.setState("display local events"); // or whatever the dashboard view name is
+        viewManagerModel.setState(ViewNames.DISPLAY_LOCAL_EVENTS);
         viewManagerModel.firePropertyChange();
     }
-
 
 }

--- a/src/main/java/interface_adapter/search_event_by_name/SearchEventByNamePresenter.java
+++ b/src/main/java/interface_adapter/search_event_by_name/SearchEventByNamePresenter.java
@@ -1,6 +1,7 @@
 package interface_adapter.search_event_by_name;
 
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewNames;
 import use_case.search_event_by_name.SearchEventByNameOutputBoundary;
 import use_case.search_event_by_name.SearchEventByNameOutputData;
 
@@ -38,7 +39,7 @@ public class SearchEventByNamePresenter implements SearchEventByNameOutputBounda
 
     @Override
     public void switchToDashboardView() {
-        viewManagerModel.setState("display local events");
+        viewManagerModel.setState(ViewNames.DISPLAY_LOCAL_EVENTS);
         viewManagerModel.firePropertyChange();
     }
 }

--- a/src/main/java/use_case/save_event/SaveEventInteractor.java
+++ b/src/main/java/use_case/save_event/SaveEventInteractor.java
@@ -9,11 +9,11 @@ import java.util.List;
 public class SaveEventInteractor implements SaveEventInputBoundary {
 
     private SaveEventOutputBoundary eventPresenter;
-    private FileSavedEventsDataAccessObject savedEventsDAO;
+    private SaveEventDataAccessInterface savedEventsDAO;
     private LoginUserDataAccessInterface userDataAccess;
 
     public SaveEventInteractor(SaveEventOutputBoundary outputBoundary,
-                               FileSavedEventsDataAccessObject savedEventsDAO,
+                               SaveEventDataAccessInterface savedEventsDAO,
                                LoginUserDataAccessInterface userDataAccess) {
         this.eventPresenter = outputBoundary;
         this.savedEventsDAO = savedEventsDAO;

--- a/src/main/java/view/CalendarView.java
+++ b/src/main/java/view/CalendarView.java
@@ -16,6 +16,7 @@ import javax.swing.SwingConstants;
 
 import entity.Location;
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewNames;
 import interface_adapter.calendarFlow.CalendarFlowController;
 
 /**
@@ -24,7 +25,7 @@ import interface_adapter.calendarFlow.CalendarFlowController;
  * that coordinate multiple UI elements. This follows Clean Architecture principles
  */
 public class CalendarView extends JPanel implements ActionListener {
-    private final String viewName = "calendar view";
+    private final String viewName = ViewNames.CALENDAR;
     private final JLabel monthYearLabel = new JLabel("", SwingConstants.CENTER);
     private final JButton previousMonthButton = new JButton("◀");
     private final JButton nextMonthButton = new JButton("▶");

--- a/src/main/java/view/DisplayLocalEventsView.java
+++ b/src/main/java/view/DisplayLocalEventsView.java
@@ -3,6 +3,7 @@ package view;
 import entity.Event;
 import entity.Location;
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewNames;
 import interface_adapter.search.SearchController;
 import interface_adapter.display_local_events.DisplayLocalEventsController;
 import interface_adapter.display_local_events.DisplayLocalEventsViewModel;
@@ -40,7 +41,7 @@ public class DisplayLocalEventsView extends JPanel implements PropertyChangeList
 
     private CalendarView calendarView;
 
-    private final String viewName = "display local events";
+    private final String viewName = ViewNames.DISPLAY_LOCAL_EVENTS;
 
     // Location components
     private UpdateLocationController updateLocationController;
@@ -830,21 +831,21 @@ public class DisplayLocalEventsView extends JPanel implements PropertyChangeList
         }
 
         if (viewManagerModel != null) {
-            viewManagerModel.setState("calendar view");
+            viewManagerModel.setState(ViewNames.CALENDAR);
             viewManagerModel.firePropertyChange();
         }
     }
 
     private void navigateToSavedEvents() {
         if (viewManagerModel != null) {
-            viewManagerModel.setState("save event");
+            viewManagerModel.setState(ViewNames.SAVE_EVENTS);
             viewManagerModel.firePropertyChange();
         }
     }
 
     private void handleLogout() {
         userLocation = null;
-        locationLoaded = false;  // Reset so location can be loaded on next login
+        locationLoaded = false;
         selectedDate = null;
         updateDateFilterDisplay();
         if (currentLocationLabel != null) {
@@ -852,7 +853,7 @@ public class DisplayLocalEventsView extends JPanel implements PropertyChangeList
             currentLocationLabel.setForeground(new Color(255, 200, 200));
         }
         if (viewManagerModel != null) {
-            viewManagerModel.setState("log in");
+            viewManagerModel.setState(ViewNames.LOGIN);
             viewManagerModel.firePropertyChange();
         }
     }

--- a/src/main/java/view/EventDescriptionView.java
+++ b/src/main/java/view/EventDescriptionView.java
@@ -3,6 +3,7 @@ package view;
 import entity.Event;
 import entity.Location;
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewNames;
 import interface_adapter.event_description.EventDescriptionViewModel;
 import interface_adapter.save_event.SaveEventController;
 import use_case.save_event.SaveEventInteractor;
@@ -37,7 +38,7 @@ public class EventDescriptionView extends JPanel implements PropertyChangeListen
     private Event currentEvent;
 
     // Track which view we came from for back navigation
-    private String previousViewName = "display local events";
+    private String previousViewName = ViewNames.DISPLAY_LOCAL_EVENTS;
 
     // UI Components
     private final JLabel titleLabel = new JLabel("", SwingConstants.LEFT);

--- a/src/main/java/view/EventListByDateView.java
+++ b/src/main/java/view/EventListByDateView.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 import entity.Event;
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewNames;
 import interface_adapter.calendarFlow.CalendarFlowController;
 import interface_adapter.calendarFlow.CalendarFlowState;
 import interface_adapter.calendarFlow.CalendarFlowViewModel;
@@ -37,7 +38,7 @@ import interface_adapter.calendarFlow.CalendarFlowViewModel;
  * Users can click on individual events to view more details.
  */
 public class EventListByDateView extends JPanel implements PropertyChangeListener {
-    private final String viewName = "event list by date";
+    private final String viewName = ViewNames.EVENT_LIST_BY_DATE;
     private CalendarFlowViewModel calendarFlowViewModel;
     private CalendarFlowController calendarFlowController;
     private ViewManagerModel viewManagerModel;

--- a/src/main/java/view/LoggedInView.java
+++ b/src/main/java/view/LoggedInView.java
@@ -1,5 +1,6 @@
 package view;
 
+import interface_adapter.ViewNames;
 import interface_adapter.logged_in.ChangePasswordController;
 import interface_adapter.logged_in.LoggedInState;
 import interface_adapter.logged_in.LoggedInViewModel;
@@ -19,7 +20,7 @@ import java.beans.PropertyChangeListener;
  */
 public class LoggedInView extends JPanel implements ActionListener, PropertyChangeListener {
 
-    private final String viewName = "logged in";
+    private final String viewName = ViewNames.LOGGED_IN;
     private final LoggedInViewModel loggedInViewModel;
     private final JLabel passwordErrorField = new JLabel();
     private ChangePasswordController changePasswordController = null;

--- a/src/main/java/view/LoginView.java
+++ b/src/main/java/view/LoginView.java
@@ -1,5 +1,6 @@
 package view;
 
+import interface_adapter.ViewNames;
 import interface_adapter.login.LoginController;
 import interface_adapter.login.LoginState;
 import interface_adapter.login.LoginViewModel;
@@ -19,7 +20,7 @@ import java.beans.PropertyChangeListener;
  */
 public class LoginView extends JPanel implements ActionListener, PropertyChangeListener {
 
-    private final String viewName = "log in";
+    private final String viewName = ViewNames.LOGIN;
     private final LoginViewModel loginViewModel;
 
     private final JTextField usernameInputField = new JTextField(15);

--- a/src/main/java/view/SaveEventsView.java
+++ b/src/main/java/view/SaveEventsView.java
@@ -27,6 +27,7 @@ import javax.swing.border.EmptyBorder;
 
 import entity.Event;
 import interface_adapter.ViewManagerModel;
+import interface_adapter.ViewNames;
 import interface_adapter.save_event.SaveEventController;
 import interface_adapter.save_event.SaveEventViewModel;
 import use_case.save_event.SaveEventInteractor;
@@ -71,7 +72,7 @@ public class SaveEventsView extends JPanel implements PropertyChangeListener {
     private static final Color TEXT_MEDIUM_GRAY = new Color(150, 150, 150);
     private static final Color TEXT_DARK_GRAY = new Color(50, 50, 50);
 
-    private final String viewName = "save event";
+    private final String viewName = ViewNames.SAVE_EVENTS;
     private final SaveEventViewModel viewModel;
     private ViewManagerModel viewManagerModel;
     private SaveEventInteractor saveEventInteractor;

--- a/src/main/java/view/SearchEventByNameView.java
+++ b/src/main/java/view/SearchEventByNameView.java
@@ -2,6 +2,7 @@ package view;
 
 import javax.swing.*;
 
+import interface_adapter.ViewNames;
 import interface_adapter.save_event.SaveEventController;
 import interface_adapter.search_event_by_name.SearchEventByNameController;
 import interface_adapter.search_event_by_name.SearchEventByNameViewModel;
@@ -17,7 +18,7 @@ import java.time.format.DateTimeFormatter;
 
 public class SearchEventByNameView extends JPanel implements PropertyChangeListener {
 
-    private final String viewName = "event search";
+    private final String viewName = ViewNames.EVENT_SEARCH;
     private final SearchEventByNameViewModel searchEventByNameViewModel;
     private SearchEventByNameController eventController = null;
 

--- a/src/main/java/view/SignupView.java
+++ b/src/main/java/view/SignupView.java
@@ -1,5 +1,6 @@
 package view;
 
+import interface_adapter.ViewNames;
 import interface_adapter.signup.SignupController;
 import interface_adapter.signup.SignupState;
 import interface_adapter.signup.SignupViewModel;
@@ -21,7 +22,7 @@ import java.beans.PropertyChangeListener;
  * The View for the Signup Use Case.
  */
 public class SignupView extends JPanel implements ActionListener, PropertyChangeListener {
-    private final String viewName = "sign up";
+    private final String viewName = ViewNames.SIGNUP;
 
     private final SignupViewModel signupViewModel;
     private final JTextField usernameInputField = new JTextField(15);


### PR DESCRIPTION
**Description:** 
Fixed Dependency Inversion Principle violation in SaveEventInteractor and eliminated hardcoded view name string literals throughout the codebase to improve maintainability and follow Clean Architecture principles.

**Changes Made:**
- Changed SaveEventInteractor field declaration from concrete class FileSavedEventsDataAccessObject to interface SaveEventDataAccessInterface
- Updated SaveEventInteractor constructor parameter from concrete class to interface
- Created ViewNames.java with 9 view name constants and replaced all hardcoded string literals with ViewNames constants in view and presenter files
- Also updated viewName field declarations from string literals to constants